### PR TITLE
V0.9.2 onCancel Prop Function Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ function App() {
 
 React-Modal-Fly has two primary modes, Single View and Workflow.
 
-#### Single View Mode
+### Single View Mode
 Single View Mode displays its contents like a traditional modal. 
 ```jsx
 <Modalfly
@@ -43,7 +43,7 @@ onClose={this.handleClose}
 </Modalfly>
 ```
 
-#### Workflow Mode
+### Workflow Mode
 Workflow Mode accepts multiple `Step` components that can be navigated using a simple function.
 ```jsx
 <Modalfly
@@ -88,11 +88,33 @@ Default value is in **bold**.
 |footerContent | `String` | "left", "center", "**right**", "spaceBetween", "spaceAround", "spaceEvenly"|Controls how the footer content will be aligned. |
 | footerStyle | `Object` | **null** | Inline style object |
 |onClose | `func` | **None** | If an onClose function is not provided, the close icon button is not displayed. |
+|resetSteps| `Boolean` | **`true`**, `false` | If `false`, the current step is not reset to `0` after calling the onClose handler. This is useful for close warnings. *Only applies to `workflow` mode.* |
 |show | `Boolean` | `True`, **`False`** | Controls whether or not the Modal is displayed. |
 |size | `String` | "small", "**medium**", "large", "extraLarge" | The size of the modal.
 |style | `Object` | **null** | Inline style object |
 |title      | `String` | "**Attention**" |Sets the modal title. |
 |workflow | `Boolean` | `True`, **`False`** | Controls whether or not the Modal is in workflow mode. |
+
+#### Closer Look: `onClose`  & `resetSteps` Props 
+The `resetSteps` prop is useful for when you want to execute some custom behavior (close warning) when the close button is clicked *before*  without the current step reset to `0` (first step). View the function logic below for a better understanding. The included demo shows this in action.
+
+`src/modalfly/components/Modalfly/Modalfly.js`
+```js
+const  onCancel  =  ()  => {
+	//Check 'resetSteps' prop, if 'false', do not reset steps.
+	let reset = props.resetSteps ===  undefined  ?  true  : props.resetSteps;
+	//Always reset when in 'single view' mode
+	if (props.workflow ===  undefined) {
+		reset =  true;
+	}
+	//Call client's onClose handler
+	props.onClose();
+	//Reset workflow steps
+	if (reset) {
+		dispatch({ type: actions.RESET });
+	}
+}
+```
 
 #### Step Component Props
 Default value is in **bold**.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Default value is in **bold**.
 |workflow | `Boolean` | `True`, **`False`** | Controls whether or not the Modal is in workflow mode. |
 
 #### Closer Look: `onClose`  & `resetSteps` Props 
-The `resetSteps` prop is useful for when you want to execute some custom behavior (close warning) when the close button is clicked *before*  without the current step reset to `0` (first step). View the function logic below for a better understanding. The included demo shows this in action.
+The `resetSteps` prop is useful for when you want to execute some custom behavior (close warning) when the close button is clicked *before*  without the current step reset to `0` (first step). The included demo shows this in action. View the function logic below for a better understanding.
 
 `src/modalfly/components/Modalfly/Modalfly.js`
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-modal-fly",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "dist/index.js",
   "private": true,
   "peerDependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ class App extends Component {
 		this.state = {
 			showModal1: false,
 			showModal2: false,
+			resetSteps: true,
 			firstName: '',
 			lastName: '',
 			phone: '',
@@ -33,9 +34,14 @@ class App extends Component {
 		});
 	}
 
-	handleComplete = e => {
+	handleComplete = () => {
 		this.setState(prevState => ({ showModal1: !prevState.showModal1 }));
 		Steps.complete();
+	}
+
+	handleResetCheckbox = (e) => {
+		const { target } = e;
+		this.setState({resetSteps: target.checked});
 	}
 
 	render() {
@@ -147,6 +153,7 @@ class App extends Component {
 
 					{/* MODAL COMPONENT 1 */}
 					<Modalfly size='extraLarge' workflow
+						resetSteps={this.state.resetSteps}
 						show={this.state.showModal1} onClose={this.closeModal1}
 					>
 						{steps}
@@ -182,6 +189,19 @@ class App extends Component {
 								<button name='workflowModal' className="btn btn-lg btn-primary" onClick={this.handleShowClick}>
 									Open Workflow Modal
 								</button>
+								<div className="form-group">
+									<div className="checkbox">
+										<input
+											checked={this.state.resetSteps}
+											onChange={this.handleResetCheckbox} 
+											type="checkbox" /> Reset steps after closing modal
+									</div>
+								</div>
+								<strong>Note: </strong>
+								<span>If disabled, steps are not reset when clicking the close button. This allows you to continue with 
+									closing the modal and keep your current step so that if the modal is opened again, the current step is maintained.  
+									One could also implement some effect when clicking the close icon. For example, this could be used to show a warning
+									to the user before closing and reseting.</span>
 							</div>
 							<div className="col-md-6">
 								<button name='singleViewModal' className="btn btn-lg btn-default" onClick={this.handleShowClick}>

--- a/src/modalfly/components/Modalfly/Modalfly.js
+++ b/src/modalfly/components/Modalfly/Modalfly.js
@@ -27,7 +27,7 @@ export function Modalfly(props) {
     //Get container and footer styles
     const mfStyle = getContainerStyle(props);
     const footerStyle = getFooterStyle(props);
-    
+
     if (!props.show) {
         return null;
     }
@@ -44,7 +44,7 @@ export function Modalfly(props) {
         const isAnObject = typeof children === 'object' && children !== null;
         const isAnArray = Array.isArray(children);
         if (isAnObject && !isAnArray) {
-            return (<h3 style={{color: "red"}}>'Modalfly' Error: At least two 'Step' components are required for workflow mode.</h3>)
+            return (<h3 style={{ color: "red" }}>'Modalfly' Error: At least two 'Step' components are required for workflow mode.</h3>)
         }
         //Count the current steps
         currentStepCount = children.length;
@@ -95,9 +95,18 @@ export function Modalfly(props) {
     }
 
     const onCancel = () => {
-        dispatch({ type: actions.RESET });
-        //Close modal
+        //Check 'resetSteps' prop, if 'false', do not reset steps.
+        let reset = props.resetSteps === undefined ? true : props.resetSteps;
+        //Always reset when in 'single view' mode
+        if (props.workflow === undefined) {
+            reset = true;
+        }
+        //Call client's onClose handler
         props.onClose();
+        //Reset workflow steps
+        if (reset) {
+            dispatch({ type: actions.RESET });
+        }
     }
 
     const contentArea = () => {


### PR DESCRIPTION
### Changes
- This patch improves flexibility when the modal is in workflow mode.
- When in workflow mode and `resetSteps` prop equals `false`, clicking on the close button icon, stops the steps from being automatically reset.